### PR TITLE
tweaks to task 2 and auth flows

### DIFF
--- a/app/views/auth/v9/create-email.html
+++ b/app/views/auth/v9/create-email.html
@@ -25,7 +25,7 @@ Enter your email address
       Enter your email address
     </h1>
 
-    <form class="form" action="/auth/v9/create-checkemail" method="post">
+    <form class="form" action="/auth/v9/create-account-exists" method="post">
       <div class="govuk-form-group">
         <!-- <div id="email-hint" class="govuk-hint">
             We’ll only use this to send you a receipt

--- a/app/views/auth/v9/signin-email-2.html
+++ b/app/views/auth/v9/signin-email-2.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block pageTitle %}
-Enter your email address to sign in to your GOV.UK One Login
+Enter your email address to sign in to GOV.UK One Login
 {% endblock %}
 
 {% block header %}
@@ -22,7 +22,7 @@ Enter your email address to sign in to your GOV.UK One Login
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Enter your email address to sign in to your GOV.UK One Login
+      Enter your email address to sign in to GOV.UK One Login
     </h1>
 
     <form class="form" action="/auth/v9/signin-password-2" method="post">

--- a/app/views/auth/v9/signin-password.html
+++ b/app/views/auth/v9/signin-password.html
@@ -27,7 +27,6 @@ Enter your password
 
           <div class="gem-c-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
             <div class="govuk-form-group">
-              <label for="password" class="gem-c-label govuk-label">Password</label>
               <div class="gem-c-show-password__input-wrapper">
                 <input name="password[login]" class="gem-c-input govuk-input gem-c-input--with-password govuk-!-width-two-thirds" id="password" type="password" spellcheck="false" autocomplete="off" aria-describedby="password-hint">
                 <span class="govuk-visually-hidden" aria-live="polite">Your password is hidden</span>

--- a/app/views/find-a-lost-teacher-reference-number/check-answers.html
+++ b/app/views/find-a-lost-teacher-reference-number/check-answers.html
@@ -57,6 +57,34 @@ Check your answers – {{ serviceName }} – GOV.UK Prototype Kit
             </a>
           </dd>
         </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Awarded qualified teacher status (QTS)
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="#">
+              Change
+              <span class="govuk-visually-hidden"> awarded qualified teacher status (QTS)</span>
+            </a>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            QTS awarded by a university, SCITT or school
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Yes
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <a href="#">
+              Change
+              <span class="govuk-visually-hidden"> QTS awarded by a university, SCITT or school</span>
+            </a>
+          </dd>
+        </div>
       </dl>
 
       <p>If we find a TRN matching your details, we will send it to the email address for your GOV.UK One Login: email@example.com.</p>

--- a/app/views/find-a-lost-teacher-reference-number/check-if-you-have-a-trn.html
+++ b/app/views/find-a-lost-teacher-reference-number/check-if-you-have-a-trn.html
@@ -1,8 +1,12 @@
-{% extends "layout-trn.html" %}
+{% extends "layout.html" %}
 
 {% block pageTitle %}
 Check if you have a TRN – {{ serviceName }}
 {% endblock %}
+
+{% set serviceName %}
+  Find a lost teacher reference number (TRN)
+{% endset%}
 
 {% block beforeContent %}
   <a class="govuk-back-link" href="javascript:window.history.back()">Back</a>


### PR DESCRIPTION
Tweaks:

- Task 1 create auth flow goes to "account already exists" page
- Removed "your" verbiage from sign in auth flows for task 1 and 2
- Updated task 2 check answer page to include all answered questions
- removed service header from Check if you have a TRN page as this comes before the One Login auth flow