### PR TITLE
Changes for round 2 of UR

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -79,10 +79,20 @@ $govuk-assets-path: '/govuk/assets/';
         margin-bottom: 20px;
     }
 
+    // other task cards
+
+    .service-card--other-task {
+      border-top: 1px solid #b1b4b6;
+      padding-top: 15px;
+      margin-bottom: 20px;
+  }
+
     // account blurb
 
     .account-blurb {
         padding: 20px;
+        margin-top: 40px;
+        margin-bottom: 20px;
         background-color: #f3f2f1;
     }
 

--- a/app/views/account-header.html
+++ b/app/views/account-header.html
@@ -32,7 +32,7 @@
           <ul id="navigation" class="govuk-header__navigation-list">
             <li class="govuk-header__navigation-item {% if activeServiceNavItem == "payg-home" %} govuk-header__navigation-item--active {% endif %}">
                 <a class="govuk-header__link" href="/account/account-home">
-                Home
+                Your services
                 </a>
             </li>
             <li class="govuk-header__navigation-item {% if activeServiceNavItem == "your-details" %} govuk-header__navigation-item--active {% endif %}">
@@ -60,14 +60,14 @@
           
           <button  type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" aria-expanded="false">
             <svg id="account-menu-button" class="account-menu-icon account-menu-icon-toggle" width="16" height="10" viewBox="0 0 16 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" clip-rule="evenodd" d="M0 2.25234L1.34535 0.772461L7.67267 6.52458L14 0.772461L15.3453 2.25234L7.67267 9.2275L0 2.25234Z" fill="#1D70B8"/>
-            </svg> 
+              <path d="M15 8.18176L8 1.81813L0.999999 8.18176" stroke="#1D70B8" stroke-width="2"/>
+            </svg>
           </button>
           
           <ul id="navigation-mobile" class="govuk-header__navigation-list" style="display: none;">
             <li class="govuk-header__navigation-item {% if activeServiceNavItem == "payg-home" %} govuk-header__navigation-item--active {% endif %}">
                 <a class="govuk-header__link" href="/account/account-home">
-                Home
+                Your services
                 </a>               
             </li>
             <li class="govuk-header__navigation-item {% if activeServiceNavItem == "your-details" %} govuk-header__navigation-item--active {% endif %}">

--- a/app/views/account/account-delete.html
+++ b/app/views/account/account-delete.html
@@ -5,7 +5,7 @@
 {% set activeServiceNavItem = "your-details" %}
 
 {% block pageTitle %}
-  GOV.UK One Login - Settings - Delete account
+  GOV.UK One Login - Settings - Delete
 {% endblock %}
 
 {% block beforeContent %}
@@ -15,6 +15,10 @@
   },
   html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
 }) }}
+{{ govukBackLink({
+  text: "Back",
+  href: "javascript:window.history.back()"
+}) }}
 {% endblock %}
 
 {% block content %}
@@ -22,25 +26,28 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
-        Are you sure you want to delete your GOV.UK One Login
+        Are you sure you want to delete your GOV.UK One Login?
       </h1>
       
-      <p>This will delete your GOV.UK One Login account. </p>
+      <p>This will delete the sign in details for your GOV.UK One Login.</p>
 
-      <p>It will not delete any other government accounts you may have, such as Universal Credit.</p>
+      {{ govukInsetText({
+        text: "There are some government services that you cannot use with your GOV.UK One Login yet (for example Universal Credit). These services will not be affected."
+      }) }}
 
       <h2 class="govuk-heading-m">What happens after you delete your GOV.UK One Login</h2>
-
-      <p>Your GOV.UK One Login will not be permanently deleted straight away. </p>
 
       <p>You can change your mind within 14 days - you’ll get an email explaining what to do.</p>
 
       <p>After 14 days:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the sign in details for your GOV.UK One Login will be permanently deleted</li>
-        <li>you’ll no longer be able to sign in to services you’ve used with your GOV.UK One Login</li>
-        <li>we will notify all the services you’ve used with your GOV.UK One Login - they may contact you separately about the information they hold about you </li>
+        <li>you’ll no longer be able to sign in to services you’ve used with it</li>
       </ul>
+
+      {{ govukInsetText({
+        text: "Deleting your GOV.UK One Login will not delete the personal information held by services you’ve used."
+      }) }}
 
       <details class="govuk-details" data-module="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/account/account-home-with-trn.html
+++ b/app/views/account/account-home-with-trn.html
@@ -5,7 +5,7 @@
 {% set activeServiceNavItem = "payg-home" %}
 
 {% block pageTitle %}
-  GOV.UK One Login - Home
+  GOV.UK One Login - Your services
 {% endblock %}
 
 {% block beforeContent %}
@@ -22,37 +22,21 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Your GOV.UK One Login
+        Your services
       </h1>
       <p>
-        You’re signed in as <span class="govuk-!-font-weight-bold">name@email.com</span> 
+        You’re signed in as <span class="govuk-!-font-weight-bold">{{ data['emailAddress'] or 'your.name@example.com' }}</span> 
       </p>
 
-      <h2 class="govuk-heading-m">Services you've used</h2>
-
       <div class="service-card--with-title">
         <div class="service-card-title">
-          <h3 class="govuk-heading-s"><span class="govuk-body">Part of</span> Teacher services</h3>
+          <h3 class="govuk-heading-s">Childcare service</h3>
         </div>
         <div class="service-card-body">
-        <p><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></p>
-        <p class="service-card-date">Last used: 12 October 2022</p>
-        </div>
-      </div>
-
-      <div class="service-card--with-title">
-        <div class="service-card-title">
-          <h3 class="govuk-heading-s">The childcare service</h3>
-        </div>
-        <div class="service-card-body">
+        <p>Manage your Tax-Free Childcare and 30 hours free childcare.</p>
         <p><a href="/childcare/service-childcare-home" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
-        <p class="service-card-date">Last used: 10 October 2022</p>
+        <p class="service-card-date">Last used: 25 October 2022</p>
         </div>
-      </div>
-
-      <div class="service-card--no-title">
-        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
-        <p class="service-card-date">Last used: 22 June 2021</p>
       </div>
 
       <div class="service-card--with-title">
@@ -60,46 +44,63 @@
           <h3 class="govuk-heading-s">Personal tax account</h3>
         </div>
         <div class="service-card-body">
+        <p>Check your records and manage your details with HM Revenue and Customs (HMRC).</p>
         <p><a href="/pta/service-pta-home" class="govuk-link--no-visited-state">Go to your personal tax account</a></p>
-        <p class="service-card-date">Last used: 10 October 2019</p>
+        <p class="service-card-date">Last used: 5 September 2022</p>
         </div>
       </div>
 
-      <div class="service-card--no-title">
+      <h2 class="govuk-heading-m">
+        Other tasks
+      </h2>
+
+      <div class="service-card--other-task">
+        <p><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></p>
+        <p class="service-card-date">Last used: 25 October 2022</p>
+      </div>
+
+      <div class="service-card--other-task">
+        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
+        <p class="service-card-date">Last used: 22 June 2021</p>
+      </div>
+
+      <div class="service-card--other-task">
         <p><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></p>
         <p class="service-card-date">Last used: 14 May 2018</p>
       </div>
       
       <div class="account-blurb">
-      <h2 class="govuk-heading-m">Using GOV.UK One Login</h2>
-
-      <p>You can use GOV.UK One Login to sign in to some services on GOV.UK.</p>
-
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Services you can sign in to with GOV.UK One Login 
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <ul class="govuk-list govuk-list--bullet">
-            <li>Apply for a passport</li>
-            <li>Dart charge</li> 
-            <li>Find a lost teacher reference number (TRN)</li> 
-            <li>Licensing for exporting controlled goods (LITE)</li> 
-            <li>Personal tax account</li> 
-            <li>Recruit an apprentice</li> 
-            <li>Register for a National Professional Qualification (NPQ)</li> 
-            <li>Request a basic DBS check</li> 
-            <li>The childcare service</li> 
-          </ul>
+    
+        <h3 class="govuk-heading-m">Services you can use with your GOV.UK One Login</h3>
+        <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).</p>
+        
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Services you can use with your GOV.UK One Login
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p>These are all the services you can use with your GOV.UK One Login:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li><a href="#">Apply for a passport</a></li>
+              <li><a href="#">Dart charge</a></li> 
+              <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
+              <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
+              <li><a href="#">Personal tax account</a></li> 
+              <li><a href="#">Recruit an apprentice</a></li> 
+              <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
+              <li><a href="#">Request a basic DBS check</a></li> 
+              <li><a href="#">The childcare service</a></li> 
+            </ul>
+          </div>
+        </details>
+    
+        <p>There are some government services that you cannot use with your GOV.UK One Login yet (for example Universal Credit).</p> 
+    
+        <p>In the future, you'll be able to use your GOV.UK One Login to access all services on GOV.UK.</p> 
+        
         </div>
-      </details>
-
-      <p>GOV.UK One Login is currently separate from some other government accounts (for example Universal Credit).</p>
-
-      <p>In the future, you'll be able to use it to sign in to all services on GOV.UK.</p>
-    </div>
      
     </div>
   </div>

--- a/app/views/account/account-home.html
+++ b/app/views/account/account-home.html
@@ -5,7 +5,7 @@
 {% set activeServiceNavItem = "payg-home" %}
 
 {% block pageTitle %}
-  GOV.UK One Login - Home
+  GOV.UK One Login - Your services
 {% endblock %}
 
 {% block beforeContent %}
@@ -22,27 +22,21 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
-        Your GOV.UK One Login
+        Your services
       </h1>
       <p>
-        You’re signed in as <span class="govuk-!-font-weight-bold">name@email.com</span> 
+        You’re signed in as <span class="govuk-!-font-weight-bold">{{ data['emailAddress'] or 'your.name@example.com' }}</span> 
       </p>
-
-      <h2 class="govuk-heading-m">Services you've used</h2>
 
       <div class="service-card--with-title">
         <div class="service-card-title">
-          <h3 class="govuk-heading-s">The childcare service</h3>
+          <h3 class="govuk-heading-s">Childcare service</h3>
         </div>
         <div class="service-card-body">
+        <p>Manage your Tax-Free Childcare and 30 hours free childcare.</p>
         <p><a href="/childcare/service-childcare-home" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
-        <p class="service-card-date">Last used: 10 October 2022</p>
+        <p class="service-card-date">Last used: 25 October 2022</p>
         </div>
-      </div>
-
-      <div class="service-card--no-title">
-        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
-        <p class="service-card-date">Last used: 22 June 2021</p>
       </div>
 
       <div class="service-card--with-title">
@@ -50,46 +44,58 @@
           <h3 class="govuk-heading-s">Personal tax account</h3>
         </div>
         <div class="service-card-body">
+        <p>Check your records and manage your details with HM Revenue and Customs (HMRC).</p>
         <p><a href="/pta/service-pta-home" class="govuk-link--no-visited-state">Go to your personal tax account</a></p>
-        <p class="service-card-date">Last used: 10 October 2019</p>
+        <p class="service-card-date">Last used: 5 September 2022</p>
         </div>
       </div>
 
-      <div class="service-card--no-title">
+      <h2 class="govuk-heading-m">
+        Other tasks
+      </h2>
+
+      <div class="service-card--other-task">
+        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
+        <p class="service-card-date">Last used: 22 June 2021</p>
+      </div>
+
+      <div class="service-card--other-task">
         <p><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></p>
         <p class="service-card-date">Last used: 14 May 2018</p>
       </div>
       
       <div class="account-blurb">
-      <h2 class="govuk-heading-m">Using GOV.UK One Login</h2>
-
-      <p>You can use GOV.UK One Login to sign in to some services on GOV.UK.</p>
-
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            Services you can sign in to with GOV.UK One Login 
-          </span>
-        </summary>
-        <div class="govuk-details__text">
-          <ul class="govuk-list govuk-list--bullet">
-            <li>Apply for a passport</li>
-            <li>Dart charge</li> 
-            <li>Find a lost teacher reference number (TRN)</li> 
-            <li>Licensing for exporting controlled goods (LITE)</li> 
-            <li>Personal tax account</li> 
-            <li>Recruit an apprentice</li> 
-            <li>Register for a National Professional Qualification (NPQ)</li> 
-            <li>Request a basic DBS check</li> 
-            <li>The childcare service</li> 
-          </ul>
+    
+        <h3 class="govuk-heading-m">Services you can use with your GOV.UK One Login</h3>
+        <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).</p>
+        
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Services you can use with your GOV.UK One Login
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p>These are all the services you can use with your GOV.UK One Login:</p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li><a href="#">Apply for a passport</a></li>
+              <li><a href="#">Dart charge</a></li> 
+              <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
+              <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
+              <li><a href="#">Personal tax account</a></li> 
+              <li><a href="#">Recruit an apprentice</a></li> 
+              <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
+              <li><a href="#">Request a basic DBS check</a></li> 
+              <li><a href="#">The childcare service</a></li> 
+            </ul>
+          </div>
+        </details>
+    
+        <p>There are some government services that you cannot use with your GOV.UK One Login yet (for example Universal Credit).</p> 
+    
+        <p>In the future, you'll be able to use your GOV.UK One Login to access all services on GOV.UK.</p> 
+        
         </div>
-      </details>
-
-      <p>GOV.UK One Login is currently separate from some other government accounts (for example Universal Credit).</p>
-
-      <p>In the future, you'll be able to use it to sign in to all services on GOV.UK.</p>
-    </div>
      
     </div>
   </div>

--- a/app/views/account/account-settings.html
+++ b/app/views/account/account-settings.html
@@ -33,7 +33,7 @@
             Email address
           </dt>
           <dd class="govuk-summary-list__value">
-            name@email.com
+            {{ data['emailAddress'] or 'your.name@example.com' }}
           </dd>
           <dd class="govuk-summary-list__actions">
             <a class="govuk-link" href="#">
@@ -70,7 +70,7 @@
       </dl>
 
       <h2 class="govuk-heading-m">Delete your GOV.UK One Login</h2>
-      <p>This will permanently delete your GOV.UK One Login account. You’ll no longer be able to sign in to the services you’ve used with it.</p>
+      <p>This will permanently delete your GOV.UK One Login. You’ll no longer be able to sign in to the services you’ve used with it.</p>
       <p><a href="account-delete" class="govuk-link--no-visited-state">Delete your GOV.UK One Login</a></p>
     </div>
   </div>

--- a/app/views/auth/v9/create-account-exists-2.html
+++ b/app/views/auth/v9/create-account-exists-2.html
@@ -20,36 +20,41 @@ Enter your password
     <h1 class="govuk-heading-l">You already have a GOV.UK One Login</h1>
 
     <p class="govuk-body">There's already a GOV.UK One Login for
-      <strong>{{ data['emailAddress'] or 'email@example.com' }}</strong>
+      <strong>{{ data['emailAddress'] or 'your.name@example.com' }}</strong>
     </p>
 
-    <h3 class="govuk-heading-m">Using your GOV.UK One Login</h3>
-    <p>You can use your GOV.UK One Login with some services.</p>
+    <div class="account-blurb">
     
-    <details class="govuk-details" data-module="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Services you can sign in to with GOV.UK One Login 
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <ul class="govuk-list govuk-list--bullet">
-          <li>Apply for a passport</li>
-          <li>Dart charge</li> 
-          <li>Find a lost teacher reference number (TRN)</li> 
-          <li>Licensing for exporting controlled goods (LITE)</li> 
-          <li>Personal tax account</li> 
-          <li>Recruit an apprentice</li> 
-          <li>Register for a National Professional Qualification (NPQ)</li> 
-          <li>Request a basic DBS check</li> 
-          <li>The childcare service</li> 
-        </ul>
+      <h3 class="govuk-heading-m">Services you can use with your GOV.UK One Login</h3>
+      <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).</p>
+      
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Services you can use with your GOV.UK One Login
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>These are all the services you can use with your GOV.UK One Login:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><a href="#">Apply for a passport</a></li>
+            <li><a href="#">Dart charge</a></li> 
+            <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
+            <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
+            <li><a href="#">Personal tax account</a></li> 
+            <li><a href="#">Recruit an apprentice</a></li> 
+            <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
+            <li><a href="#">Request a basic DBS check</a></li> 
+            <li><a href="#">The childcare service</a></li> 
+          </ul>
+        </div>
+      </details>
+  
+      <p>There are some government services that you cannot use with your GOV.UK One Login yet (for example Universal Credit).</p> 
+  
+      <p>In the future, you'll be able to use your GOV.UK One Login to access all services on GOV.UK.</p> 
+      
       </div>
-    </details>
-
-    <p>GOV.UK One Login is currently separate from some other government accounts (for example Universal Credit).</p> 
-
-    <p>In the future, you'll be able to use it to sign in to all services on GOV.UK.</p> 
     
     <h3 class="govuk-heading-m" >Enter your password</h3>
 

--- a/app/views/auth/v9/create-account-exists.html
+++ b/app/views/auth/v9/create-account-exists.html
@@ -20,36 +20,41 @@ Enter your password
     <h1 class="govuk-heading-l">You already have a GOV.UK One Login</h1>
 
     <p class="govuk-body">There's already a GOV.UK One Login for
-      <strong>{{ data['emailAddress'] or 'email@example.com' }}</strong>
+      <strong>{{ data['emailAddress'] or 'your.name@example.com' }}</strong>
     </p>
 
-    <h3 class="govuk-heading-m">Using your GOV.UK One Login</h3>
-    <p>You can use your GOV.UK One Login with some services.</p>
+    <div class="account-blurb">
+    
+    <h3 class="govuk-heading-m">Services you can use with your GOV.UK One Login</h3>
+    <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).</p>
     
     <details class="govuk-details" data-module="govuk-details">
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
-          Services you can sign in to with GOV.UK One Login 
+          Services you can use with your GOV.UK One Login
         </span>
       </summary>
       <div class="govuk-details__text">
+        <p>These are all the services you can use with your GOV.UK One Login:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>Apply for a passport</li>
-          <li>Dart charge</li> 
-          <li>Find a lost teacher reference number (TRN)</li> 
-          <li>Licensing for exporting controlled goods (LITE)</li> 
-          <li>Personal tax account</li> 
-          <li>Recruit an apprentice</li> 
-          <li>Register for a National Professional Qualification (NPQ)</li> 
-          <li>Request a basic DBS check</li> 
-          <li>The childcare service</li> 
+          <li><a href="#">Apply for a passport</a></li>
+          <li><a href="#">Dart charge</a></li> 
+          <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
+          <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
+          <li><a href="#">Personal tax account</a></li> 
+          <li><a href="#">Recruit an apprentice</a></li> 
+          <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
+          <li><a href="#">Request a basic DBS check</a></li> 
+          <li><a href="#">The childcare service</a></li> 
         </ul>
       </div>
     </details>
 
-    <p>GOV.UK One Login is currently separate from some other government accounts (for example Universal Credit).</p> 
+    <p>There are some government services that you cannot use with your GOV.UK One Login yet (for example Universal Credit).</p> 
 
-    <p>In the future, you'll be able to use it to sign in to all services on GOV.UK.</p> 
+    <p>In the future, you'll be able to use your GOV.UK One Login to access all services on GOV.UK.</p> 
+    
+    </div>
     
     <h3 class="govuk-heading-m" >Enter your password</h3>
 
@@ -69,7 +74,7 @@ Enter your password
 
       </div>
 
-      <p><a href="#">I've forgotten my password</p>
+      <p><a href="#">I've forgotten my password</a></p>
 
       <button class="govuk-button" data-module="govuk-button">Continue</button>
 

--- a/app/views/auth/v9/gov-account-3.html
+++ b/app/views/auth/v9/gov-account-3.html
@@ -34,7 +34,7 @@ Sign in or create a GOV.UK account
         {% endif %}
       </h1>
 
-      <p>You can currently use GOV.UK One Login to sign in to some services on GOV.UK.<p>
+      <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).<p>
 
       <p>In the future, you'll be able to use it with all services on GOV.UK.<p>
 

--- a/app/views/auth/v9/gov-account.html
+++ b/app/views/auth/v9/gov-account.html
@@ -34,7 +34,7 @@ Sign in or create a GOV.UK account
         {% endif %}
       </h1>
 
-      <p>You can currently use GOV.UK One Login to sign in to some services on GOV.UK.<p>
+      <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).<p>
 
       <p>In the future, you'll be able to use it with all services on GOV.UK.<p>
 

--- a/app/views/childcare-header-2.html
+++ b/app/views/childcare-header-2.html
@@ -51,7 +51,7 @@
 <div id="myDIV" class="service-header" style="display: none;">
 <div class="govuk-header__container govuk-width-container">
   <ul class="govuk-list account-exposed-menu">
-    <li><a href="/account/account-home" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Home</a></li>
+    <li><a href="/account/account-home" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Your services</a></li>
     <li><a href="/account/account-settings" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Settings</a></li>
     <li><a href="/" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Sign out</a></li>
   </ul>

--- a/app/views/childcare/service-childcare-home.html
+++ b/app/views/childcare/service-childcare-home.html
@@ -48,7 +48,7 @@ The childcare service - Home
   </div>
   <div class="pta-card">
     <h3 class="govuk-heading-s"><a href="service-childcare-reconfirm">Reconfirmation</a></h3>
-    <p class="govuk-body">Confirm your details are up to date every 3 months.  You have until 31 October 2022 to reconfim your details.</p>
+    <p class="govuk-body">Confirm your details are up to date every 3 months.  You have until 27 October 2022 to reconfim your details.</p>
   </div>
   <div class="pta-card">
     <h3 class="govuk-heading-s"><a href="#">Security</a></h3>

--- a/app/views/childcare/service-childcare-secure-messages.html
+++ b/app/views/childcare/service-childcare-secure-messages.html
@@ -29,14 +29,9 @@ Secure messages - The childcare service
         </thead>
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">12 October 2022</th>
+            <th scope="row" class="govuk-table__header">25 October 2022</th>
             <th scope="row" class="govuk-table__header"><a class="govuk-link" href="service-childcare-secure-message.html">30 hours tax-free childcare for NAME</a></td>
             <th scope="row" class="govuk-table__header">Unread</td>
-          </tr>
-          <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">12 October 2022</th>
-            <th scope="row" class="govuk-table__header"><a class="govuk-link" href="#">Tax-free childcare for NAME</a></td>
-              <th scope="row" class="govuk-table__header">Unread</td>
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">7 July 2022</th>
@@ -44,8 +39,8 @@ Secure messages - The childcare service
             <td class="govuk-table__cell">Read</td>
           </tr>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">7 July 2022</th>
-            <td class="govuk-table__cell">Tax-free childcare for NAME</td>
+            <td class="govuk-table__cell">19 April 2022</th>
+            <td class="govuk-table__cell">30 hours tax-free childcare for NAME</td>
             <td class="govuk-table__cell">Read</td>
           </tr>
         </tbody>

--- a/app/views/childcare/service-childcare-summary.html
+++ b/app/views/childcare/service-childcare-summary.html
@@ -61,7 +61,7 @@ The childcare service - Reconfirmation summary
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header"><span class="govuk-body">Email</span></th>
-          <td class="govuk-table__cell">name@email.com</td>
+          <td class="govuk-table__cell">{{ data['emailAddress'] or 'your.name@example.com' }}</td>
         </tr>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header"><span class="govuk-body">Telephone number</span></th>

--- a/app/views/find-a-lost-teacher-reference-number/check-answers.html
+++ b/app/views/find-a-lost-teacher-reference-number/check-answers.html
@@ -87,7 +87,7 @@ Check your answers – {{ serviceName }} – GOV.UK Prototype Kit
         </div>
       </dl>
 
-      <p>If we find a TRN matching your details, we will send it to the email address for your GOV.UK One Login: email@example.com.</p>
+      <p>If we find a TRN matching your details, we will send it to the email address for your GOV.UK One Login: <span class="govuk-!-font-weight-bold">{{ data['emailAddress'] or 'your.name@example.com' }}</span>.</p>
 
       <form action="confirmation" method="post" novalidate>
 

--- a/app/views/notify/reconfirmation.html
+++ b/app/views/notify/reconfirmation.html
@@ -11,7 +11,7 @@
 <p class="govuk-body govuk-!-font-weight-bold">Childcare service reminder - confirm your details are up to date</p>
 
 <p>
-  To continue getting Tax-Free Childcare or 30 hours free childcare, you must confirm your details are up to date with us by <span class="govuk-body govuk-!-font-weight-bold">17 October 2022</span>.
+  To continue getting Tax-Free Childcare or 30 hours free childcare, you must confirm your details are up to date with us by <span class="govuk-body govuk-!-font-weight-bold">27 October 2022</span>.
 </p>
 
     <p class="govuk-body">

--- a/app/views/trn-header.html
+++ b/app/views/trn-header.html
@@ -51,7 +51,7 @@
 <div id="myDIV" class="service-header" style="display: none;">
 <div class="govuk-header__container govuk-width-container">
   <ul class="govuk-list account-exposed-menu">
-    <li><a href="/account/account-home-with-trn" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Home</a></li>
+    <li><a href="/account/account-home-with-trn" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Your services</a></li>
     <li><a href="/account/account-settings" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Settings</a></li>
     <li><a href="/" class="govuk-link govuk-heading-s govuk-link--no-visited-state service-header-link">Sign out</a></li>
   </ul>


### PR DESCRIPTION
Changes for round 2 of UR including:

- service header and account navigation menu link text changes from "Home" to "Your services"
- introduce two sections of the account home/service dashboard service cards
- live email recall to show the email entered in the prototype or use "your.name@example.com" if no email is entered
- the delete GOV.UK One Login page language
- blurb explaining GOV.UK One Login including the list of other services people can access with GOV.UK One Login