### PR TITLE
UR round 2 typo fixes and small tweaks

### DIFF
--- a/app/views/account/account-delete.html
+++ b/app/views/account/account-delete.html
@@ -60,8 +60,8 @@
             <li>Apply for a passport</li>
             <li>Personal tax account</li>
             <li>Request a basic DBS check</li>
-            <li>Teacher services</li>
-            <li>The childcare service</li>
+            <li>Find a lost teacher reference number (TRN)</li>
+            <li>Childcare service</li>
           </ul>
         </div>
       </details>

--- a/app/views/account/account-home-with-trn.html
+++ b/app/views/account/account-home-with-trn.html
@@ -34,7 +34,7 @@
         </div>
         <div class="service-card-body">
         <p>Manage your Tax-Free Childcare and 30 hours free childcare.</p>
-        <p><a href="/childcare/service-childcare-home" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
+        <p><a href="/childcare/service-childcare-home-confirmed" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
         <p class="service-card-date">Last used: 25 October 2022</p>
         </div>
       </div>
@@ -83,15 +83,15 @@
           <div class="govuk-details__text">
             <p>These are all the services you can use with your GOV.UK One Login:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li><a href="#">Apply for a passport</a></li>
-              <li><a href="#">Dart charge</a></li> 
-              <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
-              <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
-              <li><a href="#">Personal tax account</a></li> 
-              <li><a href="#">Recruit an apprentice</a></li> 
-              <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
-              <li><a href="#">Request a basic DBS check</a></li> 
-              <li><a href="#">The childcare service</a></li> 
+              <li><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></li>
+              <li><a href="https://www.gov.uk/pay-dartford-crossing-charge" class="govuk-link--no-visited-state">Dart charge</a></li> 
+              <li><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></li> 
+              <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
+              <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
+              <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
+              <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
+              <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+              <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
             </ul>
           </div>
         </details>

--- a/app/views/account/account-home.html
+++ b/app/views/account/account-home.html
@@ -34,7 +34,7 @@
         </div>
         <div class="service-card-body">
         <p>Manage your Tax-Free Childcare and 30 hours free childcare.</p>
-        <p><a href="/childcare/service-childcare-home" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
+        <p><a href="/childcare/service-childcare-home-confirmed" class="govuk-link--no-visited-state">Go to your childcare account</a></p>
         <p class="service-card-date">Last used: 25 October 2022</p>
         </div>
       </div>
@@ -78,15 +78,15 @@
           <div class="govuk-details__text">
             <p>These are all the services you can use with your GOV.UK One Login:</p>
             <ul class="govuk-list govuk-list--bullet">
-              <li><a href="#">Apply for a passport</a></li>
-              <li><a href="#">Dart charge</a></li> 
-              <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
-              <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
-              <li><a href="#">Personal tax account</a></li> 
-              <li><a href="#">Recruit an apprentice</a></li> 
-              <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
-              <li><a href="#">Request a basic DBS check</a></li> 
-              <li><a href="#">The childcare service</a></li> 
+              <li><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></li>
+              <li><a href="https://www.gov.uk/pay-dartford-crossing-charge" class="govuk-link--no-visited-state">Dart charge</a></li> 
+              <li><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></li> 
+              <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
+              <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
+              <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
+              <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
+              <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+              <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
             </ul>
           </div>
         </details>

--- a/app/views/auth/v9/create-account-exists-2.html
+++ b/app/views/auth/v9/create-account-exists-2.html
@@ -37,15 +37,15 @@ Enter your password
         <div class="govuk-details__text">
           <p>These are all the services you can use with your GOV.UK One Login:</p>
           <ul class="govuk-list govuk-list--bullet">
-            <li><a href="#">Apply for a passport</a></li>
-            <li><a href="#">Dart charge</a></li> 
-            <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
-            <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
-            <li><a href="#">Personal tax account</a></li> 
-            <li><a href="#">Recruit an apprentice</a></li> 
-            <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
-            <li><a href="#">Request a basic DBS check</a></li> 
-            <li><a href="#">The childcare service</a></li> 
+            <li><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></li>
+            <li><a href="https://www.gov.uk/pay-dartford-crossing-charge" class="govuk-link--no-visited-state">Dart charge</a></li> 
+            <li><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></li> 
+            <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
+            <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
+            <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
+            <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
+            <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+            <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
           </ul>
         </div>
       </details>

--- a/app/views/auth/v9/create-account-exists.html
+++ b/app/views/auth/v9/create-account-exists.html
@@ -37,15 +37,15 @@ Enter your password
       <div class="govuk-details__text">
         <p>These are all the services you can use with your GOV.UK One Login:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li><a href="#">Apply for a passport</a></li>
-          <li><a href="#">Dart charge</a></li> 
-          <li><a href="#">Find a lost teacher reference number (TRN)</a></li> 
-          <li><a href="#">Licensing for exporting controlled goods (LITE)</a></li> 
-          <li><a href="#">Personal tax account</a></li> 
-          <li><a href="#">Recruit an apprentice</a></li> 
-          <li><a href="#">Register for a National Professional Qualification (NPQ)</a></li> 
-          <li><a href="#">Request a basic DBS check</a></li> 
-          <li><a href="#">The childcare service</a></li> 
+          <li><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></li>
+          <li><a href="https://www.gov.uk/pay-dartford-crossing-charge" class="govuk-link--no-visited-state">Dart charge</a></li> 
+          <li><a href="/find-a-lost-teacher-reference-number/start" class="govuk-link--no-visited-state">Find a lost teacher reference number (TRN)</a></li> 
+          <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
+          <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
+          <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
+          <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
+          <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+          <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
         </ul>
       </div>
     </details>

--- a/app/views/auth/v9/gov-account-3.html
+++ b/app/views/auth/v9/gov-account-3.html
@@ -34,7 +34,7 @@ Sign in or create a GOV.UK account
         {% endif %}
       </h1>
 
-      <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).<p>
+      <p>You can use your GOV.UK One Login to access some government services.<p>
 
       <p>In the future, you'll be able to use it with all services on GOV.UK.<p>
 

--- a/app/views/auth/v9/gov-account.html
+++ b/app/views/auth/v9/gov-account.html
@@ -34,7 +34,7 @@ Sign in or create a GOV.UK account
         {% endif %}
       </h1>
 
-      <p>You can use your GOV.UK One Login to access some government services (for example your childcare account or your personal tax account).<p>
+      <p>You can use your GOV.UK One Login to access some government services.<p>
 
       <p>In the future, you'll be able to use it with all services on GOV.UK.<p>
 

--- a/app/views/childcare/service-childcare-home-confirmed.html
+++ b/app/views/childcare/service-childcare-home-confirmed.html
@@ -33,7 +33,7 @@ The childcare service - Home
     </div>
     <div class="pta-card">
       <h3 class="govuk-heading-s"><a href="#">30 hours free childcare</a></h3>
-      <p class="govuk-body">View your 30 hours free childcare codes</p>
+      <p class="govuk-body">View your 30 hours free childcare codes.</p>
     </div>
     <div class="pta-card">
       <h3 class="govuk-heading-s"><a href="service-childcare-secure-messages">Secure messages</a></h3>

--- a/app/views/childcare/service-childcare-home.html
+++ b/app/views/childcare/service-childcare-home.html
@@ -33,7 +33,7 @@ The childcare service - Home
     </div>
     <div class="pta-card">
       <h3 class="govuk-heading-s"><a href="#">30 hours free childcare</a></h3>
-      <p class="govuk-body">View your 30 hours free childcare codes</p>
+      <p class="govuk-body">View your 30 hours free childcare codes.</p>
     </div>
     <div class="pta-card">
       <h3 class="govuk-heading-s"><a href="service-childcare-secure-messages">Secure messages</a></h3>

--- a/app/views/childcare/service-childcare-reconfirm.html
+++ b/app/views/childcare/service-childcare-reconfirm.html
@@ -22,7 +22,7 @@ The childcare service - Reconfirmation
     
     <h2 class="govuk-heading-m">Before you confirm</h2>
 
-    <p>If you live in England and your child is about to start reception class, you won’t be eligible for 30 hours free childcare any more. You can still use your Tax-Free Childcare account, if you have one. Or you can reconfirm your details to apply to Tax-Free Childcare, if you haven’t already done that. Use the childcare calculator to check wihether this is the best support for your child.</p>
+    <p>If you live in England and your child is about to start reception class, you won’t be eligible for 30 hours free childcare any more. You can still use your Tax-Free Childcare account, if you have one. Or you can reconfirm your details to apply to Tax-Free Childcare, if you haven’t already done that. <a href="#">Use the childcare calculator</a> to check whether this is the best support for your child.</p>
 
     <h2 class="govuk-heading-m">If you don't confirm</h2>
 

--- a/app/views/find-a-lost-teacher-reference-number/start.html
+++ b/app/views/find-a-lost-teacher-reference-number/start.html
@@ -29,7 +29,7 @@
       <p>Have your National Insurance number ready, as we'll ask for this.</p>
 
       <div class="govuk-inset-text">
-        You need a GOV.UK One Login to sign into this service.
+        You need a GOV.UK One Login to sign in to this service.
       </div>
 
       <a href="check-if-you-have-a-trn.html" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">


### PR DESCRIPTION
- update links to services people can use with GOV.UK One Login in the account blurb
- fix typos
- adjust auth flow content to remove examples of services on the "You need a GOV.UK One Login to continue" pages
- link to the childcare service homepage after confirming from the account home/service dashboard