### PR TITLE
remove Request a basic DBS service

### DIFF
--- a/app/views/account/account-home-with-trn.html
+++ b/app/views/account/account-home-with-trn.html
@@ -61,11 +61,6 @@
       </div>
 
       <div class="service-card--other-task">
-        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
-        <p class="service-card-date">Last used: 22 June 2021</p>
-      </div>
-
-      <div class="service-card--other-task">
         <p><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></p>
         <p class="service-card-date">Last used: 14 May 2018</p>
       </div>
@@ -90,8 +85,7 @@
               <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
               <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
               <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
-              <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
-              <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+              <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li>
               <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
             </ul>
           </div>

--- a/app/views/account/account-home.html
+++ b/app/views/account/account-home.html
@@ -53,11 +53,6 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-8">Other services you’ve used</h2>
 
       <div class="service-card--other-task">
-        <p><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></p>
-        <p class="service-card-date">Last used: 22 June 2021</p>
-      </div>
-
-      <div class="service-card--other-task">
         <p><a href="https://www.gov.uk/apply-renew-passport" class="govuk-link--no-visited-state">Apply for a passport</a></p>
         <p class="service-card-date">Last used: 14 May 2018</p>
       </div>
@@ -83,7 +78,6 @@
               <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
               <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
               <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
-              <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
               <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
             </ul>
           </div>

--- a/app/views/auth/v9/create-account-exists-2.html
+++ b/app/views/auth/v9/create-account-exists-2.html
@@ -43,8 +43,7 @@ Enter your password
             <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
             <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
             <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
-            <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
-            <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+            <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li>
             <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
           </ul>
         </div>

--- a/app/views/auth/v9/create-account-exists.html
+++ b/app/views/auth/v9/create-account-exists.html
@@ -43,8 +43,7 @@ Enter your password
           <li><a href="https://www.gov.uk/export-control-licence" class="govuk-link--no-visited-state">Licensing for exporting controlled goods (LITE)</a></li> 
           <li><a href="https://www.gov.uk/personal-tax-account" class="govuk-link--no-visited-state">Personal tax account</a></li> 
           <li><a href="https://www.gov.uk/recruit-apprentice" class="govuk-link--no-visited-state">Recruit an apprentice</a></li> 
-          <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li> 
-          <li><a href="https://www.gov.uk/request-copy-criminal-record" class="govuk-link--no-visited-state">Request a basic DBS check</a></li> 
+          <li><a href="https://register-national-professional-qualifications.education.gov.uk/" class="govuk-link--no-visited-state">Register for a National Professional Qualification (NPQ)</a></li>
           <li><a href="/govuk/childcare-service-start" class="govuk-link--no-visited-state">The childcare service</a></li> 
         </ul>
       </div>


### PR DESCRIPTION
Removed the Request a basic DBS check service, given that it seemed a little bit odd to the teachers from the first round of user research, as their schools tended to do this for them.